### PR TITLE
The ZMQ_LINGER sock opt expects an integer

### DIFF
--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -28,7 +28,7 @@ requires '_socket_type';
 
 has linger => (
     is => 'ro',
-    isa => 'Bool',
+    isa => 'Int',
     default => 0,
 );
 


### PR DESCRIPTION
cf. http://api.zeromq.org/2-1:zmq-setsockopt

This change is based off of version 0.005, as later unrelased changes in the master branch start refering to a Message::Passing::Types module, which is neither released to CPAN nor part of Message-Passing's master branch.
