### PR TITLE
Allow the user to provide his own sockets

### DIFF
--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -15,6 +15,12 @@ has _socket => (
     clearer => '_clear_socket',
 );
 
+has socket_builder => (
+    is        => 'ro',
+    isa       => 'CodeRef',
+    predicate => '_has_socket_builder',
+);
+
 before _clear_ctx => sub {
     my $self = shift;
     if (!$self->linger) {
@@ -34,6 +40,10 @@ has linger => (
 
 sub _build_socket {
     my $self = shift;
+
+    return $self->socket_builder->($self, $self->_ctx)
+        if $self->_has_socket_builder;
+
     my $type_name = "ZeroMQ::Constants::ZMQ_" . $self->socket_type;
     my $socket = $self->_ctx->socket(do { no strict 'refs'; &$type_name() });
     if (!$self->linger) {
@@ -143,6 +153,24 @@ messages are likely to be discarded once this high water mark is exceeded
 A value of 0 disables the high water mark, meaning that messages will be
 buffered until RAM runs out.
 
+=head3 socket_builder
+
+A code reference returning a new L<ZeroMQ::Socket> instance within a new
+L<ZeroMQ::Context> every time it is called.
+
+If a value this attribute is provided, responsibility for building sockets is
+solely the callback's responsibility. None of the other attributes usually
+involved in creating sockets, such as C<socket_type>, C<linger>, or
+C<socket_hmw> will be taken into account automatically.
+
+If a socket builder callback needs to make use of the aforementioned attributes,
+it will have to do so manually by looking at the object implementing
+C<Message::Passing::ZeroMQ::Role::HasASocket>, which is going to be passed to
+the callback as the first argument upon invocation.
+
+The second and final argument passed to the callback with be a newly
+L<ZeroMQ::Context> that the new socket is expected to be created in.
+
 =head1 METHODS
 
 =head2 setsockopt
@@ -155,7 +183,7 @@ is created.
 This module exists due to the wonderful people at Suretec Systems Ltd.
 <http://www.suretecsystems.com/> who sponsored its development for its
 VoIP division called SureVoIP <http://www.surevoip.co.uk/> for use with
-the SureVoIP API - 
+the SureVoIP API -
 <http://www.surevoip.co.uk/support/wiki/api_documentation>
 
 =head1 AUTHOR, COPYRIGHT AND LICENSE


### PR DESCRIPTION
The automatic construction of ZMQ sockets is very limited currently. Instead of
forcing ourselfs to always keep up to date with whatever kind of socket options
ZMQ and its perl bindings offer and exposing them explicitly ourselfs, allow our
consumer to take control of construction of sockets if he wishes to.

Again, this is based upon the latest version of this distribution on CPAN, 0.005, as the latest code in the master branch is referencing code not yet available on either CPAN or Message-Passing's master branch.
