### PR TITLE
Fix ZeroMQ chdir'ing to /tmp/.

### DIFF
--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -3,6 +3,7 @@ use Moo::Role;
 use ZeroMQ ':all';
 use MooX::Types::MooseLike::Base qw/ :all /;
 use namespace::clean -except => 'meta';
+use File::pushd qw/tempd/;
 
 with 'Message::Passing::ZeroMQ::Role::HasAContext';
 
@@ -85,7 +86,9 @@ sub setsockopt {
         # work around ZeroMQ issue 140: ZMQ_SWAP expects to
         # be able to write to the current directory and
         # crashes if it can't
-        chdir("/tmp");
+
+        # Locally scoped var so that temp dir gets removed at end of scope
+        my $dir = tempd;
 
         $socket->setsockopt(ZMQ_SWAP, $self->socket_swap);
    }


### PR DESCRIPTION
This branch is based off tag 0.007.

Message::Passing::ZeroMQ is permanently chdir'ing to /tmp/

Can this fix be folded and a new hotfix release issued?

Thanks

gbjk
