### PR TITLE
Add compatibility with ZeroMQ 3+.

### DIFF
--- a/lib/Message/Passing/Input/ZeroMQ.pm
+++ b/lib/Message/Passing/Input/ZeroMQ.pm
@@ -41,8 +41,13 @@ after setsockopt => sub {
 sub _try_rx {
     my $self = shift();
     my $msg;
+
+    my ($major) = $self->_ctx->version();
+
+    my $flag = $major >= 3 ? ZMQ_DONTWAIT : ZMQ_NOBLOCK;
+
     try {
-        $msg = $self->_zmq_recv(ZMQ_NOBLOCK);
+        $msg = $self->_zmq_recv($flag);
     };
     if ($msg) {
         $self->output_to->consume($msg);

--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -79,7 +79,16 @@ has socket_swap => (
 
 sub setsockopt {
     my ($self, $socket) = @_;
-    $socket->set(ZMQ_HWM, 'uint64_t', $self->socket_hwm);
+
+    my ($major) = $self->_ctx->version();
+
+    if ($major >= 3) {
+        $socket->set(ZMQ_RCVHWM, 'int', $self->socket_hwm);
+        $socket->set(ZMQ_SNDHWM, 'int', $self->socket_hwm);
+    }
+    else {
+        $socket->set(ZMQ_HWM, 'uint64_t', $self->socket_hwm);
+    }
 
     if ($self->socket_swap > 0) {
         # work around ZeroMQ issue 140: ZMQ_SWAP expects to


### PR DESCRIPTION
The ZeroMQ 3 release contained some breaking changes.  I've tested this against 4.0.4, seems to work.
