### PR TITLE
Feature/ffi

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.0072
+    - Remove SWAP, since libzmq3 removes it.
+
+0.0071
+    - Fix chdir to hardcoded /tmp/ directory
+
 0.007
     - Support (and default for writeres) to swapping content out onto disk
 

--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 NEXT
+    - Fix first message (probably) not sent with libzmq3
     - Added zmq_major_version accessor
     - Remove SWAP, since libzmq3 removes it. Removes chdir
 

--- a/Changes
+++ b/Changes
@@ -1,8 +1,6 @@
-0.0072
-    - Remove SWAP, since libzmq3 removes it.
-
-0.0071
-    - Fix chdir to hardcoded /tmp/ directory
+NEXT
+    - Added zmq_major_version accessor
+    - Remove SWAP, since libzmq3 removes it. Removes chdir
 
 0.007
     - Support (and default for writeres) to swapping content out onto disk

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,7 @@ author_requires(
     'Test::NoTabs' => '0',
     'Test::Pod::Coverage' => '1.04',
     'Pod::Coverage' => '0.19',
-    'Pod::Coverage::TrustPod' => '0',
+    'Pod::Coverage::Moose' => '0',
     'Test::Spelling' => '0',
 );
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ resources(
 requires 'Moo' => '0.091011';
 requires 'namespace::clean';
 requires 'AnyEvent';
-requires 'ZeroMQ' => '0.21';
+requires 'ZMQ::FFI';
 requires 'Try::Tiny';
 requires 'Task::Weaken';
 requires 'Message::Passing' => '0.011';

--- a/README
+++ b/README
@@ -151,7 +151,7 @@ SEE ALSO
     Message::Passing::Output::ZeroMQ
     Message::Passing::Input::ZeroMQ
     Message::Passing
-    ZeroMQ
+    ZMQ::FFI
     <http://www.zeromq.org/>
     <http://zguide.zeromq.org/page:all>
 

--- a/lib/Message/Passing/Input/ZeroMQ.pm
+++ b/lib/Message/Passing/Input/ZeroMQ.pm
@@ -24,7 +24,6 @@ has socket_hwm => (
     default => 10000,
 );
 
-
 has subscribe => (
     isa => sub { ref($_[0]) eq 'ARRAY' },
     is => 'ro',

--- a/lib/Message/Passing/Input/ZeroMQ.pm
+++ b/lib/Message/Passing/Input/ZeroMQ.pm
@@ -34,13 +34,20 @@ has subscribe => (
 sub setsockopt {
     my ($self, $socket) = @_;
 
-    $socket->set(ZMQ_RCVHWM, 'int', $self->socket_hwm);
+    if ($self->zmq_major_version >= 3){
+        $socket->set(ZMQ_RCVHWM, 'int', $self->socket_hwm);
+    }
+    else {
+        $socket->set(ZMQ_HWM, 'uint64_t', $self->socket_hwm);
+    }
 
     if ($self->socket_type eq 'SUB') {
         foreach my $sub (@{ $self->subscribe }) {
             $socket->set(ZMQ_SUBSCRIBE, "binary", $sub);
         }
     }
+
+    return;
 }
 
 sub _try_rx {

--- a/lib/Message/Passing/Output/ZeroMQ.pm
+++ b/lib/Message/Passing/Output/ZeroMQ.pm
@@ -2,6 +2,8 @@ package Message::Passing::Output::ZeroMQ;
 use Moo;
 use namespace::clean -except => 'meta';
 
+use ZMQ::FFI::Constants qw/ :all /;
+
 with qw/
     Message::Passing::ZeroMQ::Role::HasASocket
     Message::Passing::Role::Output
@@ -15,13 +17,20 @@ has '+_socket' => (
 
 sub _socket_type { 'PUB' }
 
-sub _build_socket_hwm { 10000 }
-sub _build_socket_swap { 1024*1024*1024 }
+has socket_hwm => (
+    is      => 'rw',
+    default => 10000,
+);
 
 sub consume {
     my $self = shift;
     my $data = shift;
     $self->_zmq_send($data);
+}
+
+sub setsockopt {
+    my ($self, $socket) = @_;
+    $socket->set(ZMQ_SNDHWM, 'int', $self->socket_hwm);
 }
 
 1;

--- a/lib/Message/Passing/Output/ZeroMQ.pm
+++ b/lib/Message/Passing/Output/ZeroMQ.pm
@@ -46,9 +46,10 @@ sub BUILD {
     if ($self->_should_connect){
         my $socket = $self->_socket;
         return;
-        }
-    return;
     }
+
+    return;
+}
 
 sub consume {
     my ($self, $data) = @_;
@@ -62,22 +63,30 @@ sub consume {
         # warn "Alive $alive_time, so sleep time $sleep_time";
         if ($sleep_time > 0){
             Time::HiRes::sleep $sleep_time;
-            }
-        $self->socket_subscribed(1);
         }
+        $self->socket_subscribed(1);
+    }
 
     return $self->_zmq_send($data);
 }
 
 sub setsockopt {
     my ($self, $socket) = @_;
-    $socket->set(ZMQ_SNDHWM, 'int', $self->socket_hwm);
+
+    if ($self->zmq_major_version >= 3){
+        $socket->set(ZMQ_SNDHWM, 'int', $self->socket_hwm);
+    }
+    else {
+        $socket->set(ZMQ_HWM, 'uint64_t', $self->socket_hwm);
+    }
+
+    return;
 }
 
 after _build_socket => sub {
     my $self = shift;
     $self->socket_connect_time( Time::HiRes::time );
-    };
+};
 
 1;
 

--- a/lib/Message/Passing/Output/ZeroMQ.pm
+++ b/lib/Message/Passing/Output/ZeroMQ.pm
@@ -1,6 +1,5 @@
 package Message::Passing::Output::ZeroMQ;
 use Moo;
-use ZeroMQ ':all';
 use namespace::clean -except => 'meta';
 
 with qw/

--- a/lib/Message/Passing/ZeroMQ.pm
+++ b/lib/Message/Passing/ZeroMQ.pm
@@ -5,7 +5,7 @@ use POSIX::AtFork ();
 use Sub::Name;
 use namespace::clean -except => 'meta';
 
-our $VERSION = "0.007";
+our $VERSION = "0.0072";
 $VERSION = eval $VERSION;
 
 our @_WITH_CONTEXTS;

--- a/lib/Message/Passing/ZeroMQ.pm
+++ b/lib/Message/Passing/ZeroMQ.pm
@@ -5,7 +5,7 @@ use POSIX::AtFork ();
 use Sub::Name;
 use namespace::clean -except => 'meta';
 
-our $VERSION = "0.0072";
+our $VERSION = "0.0073";
 $VERSION = eval $VERSION;
 
 our @_WITH_CONTEXTS;

--- a/lib/Message/Passing/ZeroMQ.pm
+++ b/lib/Message/Passing/ZeroMQ.pm
@@ -1,7 +1,6 @@
 package Message::Passing::ZeroMQ;
 use strict;
 use warnings;
-use ZeroMQ qw/ :all /;
 use POSIX::AtFork ();
 use Sub::Name;
 use namespace::clean -except => 'meta';
@@ -178,7 +177,7 @@ For more detailed information about ZeroMQ and how it works, please consult the 
 
 =item L<Message::Passing>
 
-=item L<ZeroMQ>
+=item L<ZMQ::FFI>
 
 =item L<http://www.zeromq.org/>
 

--- a/lib/Message/Passing/ZeroMQ/Role/HasAContext.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasAContext.pm
@@ -11,7 +11,7 @@ use namespace::clean -except => 'meta';
 has zmq_major_version => (
     is          => 'lazy',
     isa         => Num,
-    );
+);
 
 has _ctx => (
     is => 'ro',
@@ -31,7 +31,7 @@ sub _build_zmq_major_version {
     my ($self) = @_;
     my ($major, $minor, $patch) = $self->_ctx->version;
     return $major;
-    }
+}
 
 1;
 

--- a/lib/Message/Passing/ZeroMQ/Role/HasAContext.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasAContext.pm
@@ -1,15 +1,21 @@
 package Message::Passing::ZeroMQ::Role::HasAContext;
 use Moo::Role;
 use Message::Passing::ZeroMQ ();
+use MooX::Types::MooseLike::Base qw/ :all /;
 use ZMQ::FFI;
 use Scalar::Util qw/ weaken /;
 use namespace::clean -except => 'meta';
 
 ## TODO - Support (default to?) shared contexts
 
+has zmq_major_version => (
+    is          => 'lazy',
+    isa         => Num,
+    );
+
 has _ctx => (
     is => 'ro',
-#    isa => 'ZeroMQ::Context',
+#    isa => 'ZMQ::FFI',
     lazy => 1,
     default => sub {
         my $self = shift;
@@ -20,6 +26,12 @@ has _ctx => (
     },
     clearer => '_clear_ctx',
 );
+
+sub _build_zmq_major_version {
+    my ($self) = @_;
+    my ($major, $minor, $patch) = $self->_ctx->version;
+    return $major;
+    }
 
 1;
 

--- a/lib/Message/Passing/ZeroMQ/Role/HasAContext.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasAContext.pm
@@ -1,7 +1,7 @@
 package Message::Passing::ZeroMQ::Role::HasAContext;
 use Moo::Role;
 use Message::Passing::ZeroMQ ();
-use ZeroMQ ':all';
+use ZMQ::FFI;
 use Scalar::Util qw/ weaken /;
 use namespace::clean -except => 'meta';
 
@@ -13,7 +13,7 @@ has _ctx => (
     lazy => 1,
     default => sub {
         my $self = shift;
-        my $ctx = ZeroMQ::Context->new();
+        my $ctx = ZMQ::FFI->new();
         push(@Message::Passing::ZeroMQ::_WITH_CONTEXTS, $self);
         weaken($Message::Passing::ZeroMQ::_WITH_CONTEXTS[-1]);
         $ctx;

--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -64,36 +64,6 @@ sub _build_socket {
     return $socket;
 }
 
-has socket_hwm => (
-    is => 'ro',
-    isa => Int,
-    builder => '_build_socket_hwm',
-    lazy => 1,
-);
-
-has socket_swap => (
-    is => 'ro',
-    isa => Int,
-    builder => '_build_socket_swap',
-    lazy => 1,
-);
-
-sub setsockopt {
-    my ($self, $socket) = @_;
-    $socket->set(ZMQ_HWM, 'uint64_t', $self->socket_hwm);
-
-    if ($self->socket_swap > 0) {
-        # work around ZeroMQ issue 140: ZMQ_SWAP expects to
-        # be able to write to the current directory and
-        # crashes if it can't
-
-        # Locally scoped var so that temp dir gets removed at end of scope
-        my $dir = tempd;
-
-        $socket->set(ZMQ_SWAP, 'uint64_t', $self->socket_swap);
-   }
-}
-
 has socket_bind => (
     is => 'ro',
     isa => Str,

--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -3,6 +3,7 @@ use Moo::Role;
 use ZMQ::FFI::Constants qw/ :all /;
 use MooX::Types::MooseLike::Base qw/ :all /;
 use namespace::clean -except => 'meta';
+use File::pushd qw/tempd/;
 
 with 'Message::Passing::ZeroMQ::Role::HasAContext';
 
@@ -85,7 +86,9 @@ sub setsockopt {
         # work around ZeroMQ issue 140: ZMQ_SWAP expects to
         # be able to write to the current directory and
         # crashes if it can't
-        chdir("/tmp");
+
+        # Locally scoped var so that temp dir gets removed at end of scope
+        my $dir = tempd;
 
         $socket->set(ZMQ_SWAP, 'uint64_t', $self->socket_swap);
    }

--- a/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
+++ b/lib/Message/Passing/ZeroMQ/Role/HasASocket.pm
@@ -50,7 +50,7 @@ sub _build_socket {
     if ($self->linger) {
         $socket->set_linger($self->linger);
     }
-    $self->setsockopt($socket); 
+    $self->setsockopt($socket);
     if ($self->_should_connect) {
         $socket->connect($self->connect);
     }

--- a/t/author/podcoverage.t
+++ b/t/author/podcoverage.t
@@ -2,17 +2,15 @@ use strict;
 use warnings;
 use Test::More;
 
-use Pod::Coverage 0.19;
+use Pod::Coverage::Moose;
 use Test::Pod::Coverage 1.04;
 
 my @modules = all_modules;
 our @private = ( 'BUILD' );
 foreach my $module (@modules) {
-    local @private = (@private, 'expand_class_name', 'make') if $module =~ /^Message::Passing::DSL::Factory$/;
 
     pod_coverage_ok($module, {
-        also_private   => \@private,
-        coverage_class => 'Pod::Coverage::TrustPod',
+        coverage_class => 'Pod::Coverage::Moose',
     });
 }
 

--- a/t/input.t
+++ b/t/input.t
@@ -9,21 +9,21 @@ use Message::Passing::Output::Test;
 use ZMQ::FFI::Constants qw/ :all /;
 use ZMQ::FFI;
 
-my $cv = AnyEvent->condvar;
-my $output = Message::Passing::Output::Test->new(
-    cb => sub { $cv->send;},
-);
-my $dec = Message::Passing::Filter::Decoder::JSON->new(output_to => $output);
-my $input = Message::Passing::Input::ZeroMQ->new(
-    socket_bind => 'tcp://*:5558',
-    output_to => $dec,
-);
-ok $input;
-
 # Test must fork, because it must sleep, and sleeping would put everything to sleep
 my $pid = fork();
 if ($pid){
     # Parent
+
+    my $cv = AnyEvent->condvar;
+    my $output = Message::Passing::Output::Test->new(
+        cb => sub { $cv->send;},
+    );
+    my $dec = Message::Passing::Filter::Decoder::JSON->new(output_to => $output);
+    my $input = Message::Passing::Input::ZeroMQ->new(
+        socket_bind => 'tcp://*:5558',
+        output_to   => $dec,
+    );
+    ok $input;
 
     $cv->recv;
 
@@ -49,7 +49,6 @@ elsif (defined $pid){
     exit;
     }
 else {
-    # Failed to fork
     die "Failed to fork";
     }
 

--- a/t/input.t
+++ b/t/input.t
@@ -6,7 +6,7 @@ use AnyEvent;
 use Message::Passing::Input::ZeroMQ;
 use Message::Passing::Filter::Decoder::JSON;
 use Message::Passing::Output::Test;
-use ZeroMQ qw/:all/;
+use ZMQ::FFI::Constants qw/ :all /;
 
 my $cv = AnyEvent->condvar;
 my $output = Message::Passing::Output::Test->new(
@@ -19,7 +19,7 @@ my $input = Message::Passing::Input::ZeroMQ->new(
 );
 ok $input;
 
-my $ctx = ZeroMQ::Context->new();
+my $ctx = ZMQ::FFI->new();
 my $socket = $ctx->socket(ZMQ_PUB);
 $socket->connect('tcp://127.0.0.1:5558');
 

--- a/t/input.t
+++ b/t/input.t
@@ -7,10 +7,11 @@ use Message::Passing::Input::ZeroMQ;
 use Message::Passing::Filter::Decoder::JSON;
 use Message::Passing::Output::Test;
 use ZMQ::FFI::Constants qw/ :all /;
+use ZMQ::FFI;
 
 my $cv = AnyEvent->condvar;
 my $output = Message::Passing::Output::Test->new(
-    cb => sub { $cv->send },
+    cb => sub { $cv->send;},
 );
 my $dec = Message::Passing::Filter::Decoder::JSON->new(output_to => $output);
 my $input = Message::Passing::Input::ZeroMQ->new(
@@ -19,17 +20,36 @@ my $input = Message::Passing::Input::ZeroMQ->new(
 );
 ok $input;
 
-my $ctx = ZMQ::FFI->new();
-my $socket = $ctx->socket(ZMQ_PUB);
-$socket->connect('tcp://127.0.0.1:5558');
+# Test must fork, because it must sleep, and sleeping would put everything to sleep
+my $pid = fork();
+if ($pid){
+    # Parent
 
-$socket->send('{"message":"foo"}');
+    $cv->recv;
 
-$cv->recv;
+    is $output->message_count, 1;
 
-is $output->message_count, 1;
+    is_deeply [$output->messages], [{message => "foo"}];
 
-is_deeply [$output->messages], [{message => "foo"}];
+    done_testing;
+    }
+elsif (defined $pid){
+    # Child
+    my $ctx = ZMQ::FFI->new();
+    my $socket = $ctx->socket(ZMQ_PUB);
+    $socket->connect('tcp://127.0.0.1:5558');
 
-done_testing;
+    # Sleep, because of libzmq's pub/sub
+    # See this link, and the "slow joiner" problem.
+    # http://zguide.zeromq.org/page:all#Getting-the-Message-Out
+    sleep 1;
+
+    $socket->send('{"message":"foo"}');
+
+    exit;
+    }
+else {
+    # Failed to fork
+    die "Failed to fork";
+    }
 

--- a/t/output.t
+++ b/t/output.t
@@ -7,27 +7,36 @@ use JSON qw/ encode_json /;
 use Message::Passing::Input::ZeroMQ;
 use Message::Passing::Output::Test;
 use Message::Passing::Output::ZeroMQ;
-
-my $output = Message::Passing::Output::ZeroMQ->new(
-    connect => 'tcp://127.0.0.1:5558',
-);
-
-$output->consume(encode_json {foo => 'bar'});
-
-use Message::Passing::Input::ZeroMQ;
-use Message::Passing::Output::Test;
 use Message::Passing::Filter::Decoder::JSON;
-my $cv = AnyEvent->condvar;
-my $input = Message::Passing::Input::ZeroMQ->new(
-    socket_bind => 'tcp://*:5558',
-    output_to => Message::Passing::Filter::Decoder::JSON->new(output_to => Message::Passing::Output::Test->new(
-        cb => sub { $cv->send }
-    )),
-);
-$cv->recv;
 
-is $input->output_to->output_to->message_count, 1;
-is_deeply([$input->output_to->output_to->messages], [{foo => 'bar'}]);
+my $pid = fork;
+if ($pid){
+    # Parent
+    my $cv = AnyEvent->condvar;
 
-done_testing;
+    my $input = Message::Passing::Input::ZeroMQ->new(
+        socket_bind => 'tcp://*:5558',
+        output_to => Message::Passing::Filter::Decoder::JSON->new(output_to => Message::Passing::Output::Test->new(
+            cb => sub { $cv->send }
+        )),
+    );
+    $cv->recv;
 
+    is $input->output_to->output_to->message_count, 1;
+    is_deeply([$input->output_to->output_to->messages], [{foo => 'bar'}]);
+
+    done_testing;
+    }
+elsif (defined $pid){
+    # Child
+    my $output = Message::Passing::Output::ZeroMQ->new(
+        connect => 'tcp://127.0.0.1:5558',
+    );
+
+    $output->consume(encode_json {foo => 'bar'});
+
+    exit;
+    }
+else {
+    die "Failed to fork";
+    }

--- a/t/version.t
+++ b/t/version.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More;
+use Message::Passing::Output::ZeroMQ;
+
+my $output = Message::Passing::Output::ZeroMQ->new();
+
+like $output->zmq_major_version, qr/^[234]$/, "ZMQ is a sane major version";
+
+done_testing;
+

--- a/t/version.t
+++ b/t/version.t
@@ -5,7 +5,8 @@ use Message::Passing::Output::ZeroMQ;
 
 my $output = Message::Passing::Output::ZeroMQ->new();
 
-like $output->zmq_major_version, qr/^[234]$/, "ZMQ is a sane major version";
+my $version = $output->zmq_major_version;
+like $version, qr/^[234]$/, "ZMQ is a sane major version: $version";
 
 done_testing;
 


### PR DESCRIPTION
This fixes FFI and libzmq3 handling, whilst preserving libzmq2 handling.

The need to sleep is incredibly unfortunate, but the other patterns described in 0mq's docs are just so far out of reach for us here. So we've just kept the sleeping to the most viable option we can.
Without the sleep... it'll just hang forever. Ironic, eh?

Note: CHANGELOG left with no version at the top.
ZeroMQ.pm left with 0.0073, which is what I'm testing this under currently.

Also note: By making t/stress.t fire into a non-existent receiver socket,
we can see that libzmq2 does *not* handle failure well. It grows in memory significantly before eventually ooming the whole server. You'll need more like 100 million ITRs for that though.

HTH

gbjk