### PR TITLE
Fix circular reference leak that caused test failures

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+    - Fix circular reference leak that caused test failures
 0.010
     - Update deps
 0.009

--- a/t/pushpull.t
+++ b/t/pushpull.t
@@ -26,7 +26,7 @@ my $t; $t = AnyEvent->timer(
     after => 1,
     cb => sub {
         $output->consume({});
-        $t = AnyEvent->timer(after => 1, cb => sub { $cv->send });
+        $t = AnyEvent->timer(after => 1, cb => sub { $cv->send; undef $t; });
     },
 );
 $cv->recv;


### PR DESCRIPTION
Because the callbacks close over $t, $t stayed alive past normal cleanup.

Because 'sub { $cv->send }' is a closure, the entire outer environment
was preserved because perl holds onto the full CvOUTSIDE lexical pad.

This meant that $output was also kept alive past normal cleanup.

For reasons I'm not entirely sure of, this led to AnyEvent re-entering the
event loop after execution had fallen off the end of the script (and all
other lexicals in pubsub.t being destroyed) before global destruction could
get rid of the socket for $output, and with no active timers it attempted
to poll() for read input on that socket (which was only ever used for writing,
which again I'm not entirely sure of the cause of), and the process hangs in

  poll([{fd=13, events=POLLIN}], 1, -1^C <unfinished ...>

until the alarm(30) fires and causes it to exit - which means that even
though the actual test passed, prove still considers the script as a whole
to have failed, thereby causing installation to fail.

Changing the inner callback to 'sub { $cv->send; undef $t; }' breaks the
circular reference and allows $t to be cleaned up, which allows the closure
to be cleaned up, which allows $output to correctly fall out of scope,
thereby fixing the test.

I need a drink now.